### PR TITLE
step5: ガチャに関連するテーブルの設計

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,22 +1,22 @@
 # ユーザ情報を格納するためのテーブル
 CREATE TABLE IF NOT EXISTS users (
-    id INT AUTO_INCREMENT PRIMARY KEY,
+    id VARCHAR(255) NOT NULL UNIQUE PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     token VARCHAR(255) NOT NULL UNIQUE
 );
 
 # キャラクター情報を格納するためのテーブル
 CREATE TABLE IF NOT EXISTS characters (
-    id INT AUTO_INCREMENT PRIMARY KEY,
+    id VARCHAR(255) NOT NULL UNIQUE PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     probability FLOAT NOT NULL
 );
 
 # ユーザがキャラクターを引いた記録を格納するためのテーブル
-CREATE TABLE IF NOT EXISTS results (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    user_id INT NOT NULL,
-    character_id INT NOT NULL,
+CREATE TABLE IF NOT EXISTS users_characters (
+    id VARCHAR(255) NOT NULL UNIQUE PRIMARY KEY,
+    user_id VARCHAR(255) NOT NULL,
+    character_id VARCHAR(255) NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users(id),
     FOREIGN KEY (character_id) REFERENCES characters(id)
 );

--- a/db/init.sql
+++ b/db/init.sql
@@ -4,3 +4,19 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(255) NOT NULL,
     token VARCHAR(255) NOT NULL UNIQUE
 );
+
+# キャラクター情報を格納するためのテーブル
+CREATE TABLE IF NOT EXISTS characters (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    probability FLOAT NOT NULL
+);
+
+# ユーザがキャラクターを引いた記録を格納するためのテーブル
+CREATE TABLE IF NOT EXISTS results (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    character_id INT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (character_id) REFERENCES characters(id)
+);

--- a/db/sample-data.sql
+++ b/db/sample-data.sql
@@ -1,0 +1,48 @@
+# ユーザ情報を格納するためのテーブル
+CREATE TABLE IF NOT EXISTS users (
+    id VARCHAR(255) NOT NULL UNIQUE PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    token VARCHAR(255) NOT NULL UNIQUE
+);
+
+# キャラクター情報を格納するためのテーブル
+CREATE TABLE IF NOT EXISTS characters (
+    id VARCHAR(255) NOT NULL UNIQUE PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    probability FLOAT NOT NULL
+);
+
+# ユーザがキャラクターを引いた記録を格納するためのテーブル
+CREATE TABLE IF NOT EXISTS users_characters (
+    id VARCHAR(255) NOT NULL UNIQUE PRIMARY KEY,
+    user_id VARCHAR(255) NOT NULL,
+    character_id VARCHAR(255) NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (character_id) REFERENCES characters(id)
+);
+
+# ユーザ情報のsampleデータ
+INSERT INTO users (id, name, token) VALUES 
+('a7abf496-3f37-488d-a74e-49b2b555c987', '進之介', '076a5b2c-97a9-49c7-b426-41f861386f8b'),
+('ae2547e8-c00e-43b7-9dfa-2799f24e6455', '太郎', '0adede71-78ff-4296-a3ec-8074cd56ad30');
+
+# キャラクター情報のsampleデータ
+INSERT INTO characters (id, name, probability) VALUES 
+('3c8e0b3c-9dc9-426c-879f-72bf69221a23', 'ルフィ', 0.1),
+('e4b12136-de5e-4760-abae-efeaabd0338a', 'ゾロ', 0.2),
+('5af3b613-4892-440d-8635-9ae4a13a7b4a', 'サンジ', 0.2),
+('73e1cc66-b667-4fa1-9e6d-60ae3ced2ee7', 'ナミ', 0.4),
+('6406c5aa-5467-4e9a-86f6-11dd06a2110e', 'ウソップ', 0.5),
+('754744d2-4bfe-4ff0-85b4-8ec852419131', 'チョッパー', 0.6),
+('7abd4440-b137-44d7-94b5-a48490a899f1', 'フランキー', 0.7),
+('d19b30c4-8825-410f-8a0a-f3651a8186ff', 'ブルック', 0.8),
+('93be9bce-4225-4398-b0a9-9aa2ea348bbe', 'ジンベエ', 0.2),
+('72a57228-1ae5-4a73-8ca2-738d27574a35', 'ロビン', 0.4);
+
+# ユーザがキャラクターを引いた記録のsampleデータ
+INSERT INTO users_characters (id, user_id, character_id) VALUES 
+('c4334312-d6cb-4be6-851a-1ed8423a6f15', 'a7abf496-3f37-488d-a74e-49b2b555c987', '3c8e0b3c-9dc9-426c-879f-72bf69221a23'),
+('80548478-4b03-4ef0-8b4f-7f2873e83d9e', 'a7abf496-3f37-488d-a74e-49b2b555c987', 'e4b12136-de5e-4760-abae-efeaabd0338a'),
+('dab77755-91cc-4ad2-8f2b-7dbd06d8bdaa', 'a7abf496-3f37-488d-a74e-49b2b555c987', '5af3b613-4892-440d-8635-9ae4a13a7b4a'),
+('db6ab0c6-9d58-48ed-96bf-127771e1d1ed', 'a7abf496-3f37-488d-a74e-49b2b555c987', '73e1cc66-b667-4fa1-9e6d-60ae3ced2ee7'),
+('e2162fad-a268-4f65-8218-aa756daf1739', 'ae2547e8-c00e-43b7-9dfa-2799f24e6455', '6406c5aa-5467-4e9a-86f6-11dd06a2110e');

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
     # コンテナ内にある MySQL に格納するデータを永続化させるために使用するボリュームを指定
     volumes:
       - db-volume:/var/lib/mysql
-      - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql # 初期化スクリプトをマウント
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql # 初期化スクリプトをマウント
 # ボリュームの作成
 volumes:
   db-volume:

--- a/models/user.go
+++ b/models/user.go
@@ -2,7 +2,7 @@ package models
 
 // ユーザーの構造体
 type User struct {
-	ID    int    `json:"id"`
+	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Token string `json:"token"`
 }

--- a/repositories/user.go
+++ b/repositories/user.go
@@ -17,20 +17,19 @@ func NewUserRepository(db *sql.DB) UserRepository {
 }
 
 // nameとtokenから新規ユーザーを作成する
-func (r *UserRepository) CreateUser(name string, token string) (models.User, error) {
+func (r *UserRepository) CreateUser(id, name, token string) (models.User, error) {
 	const sqlInsertUser = `
-		INSERT INTO users (name, token)
-		VALUES (?, ?);
+		INSERT INTO users (id, name, token)
+		VALUES (?, ?, ?);
 	`
 
-	result, err := r.db.Exec(sqlInsertUser, name, token)
+	_, err := r.db.Exec(sqlInsertUser, id, name, token)
 	if err != nil {
 		return models.User{}, err
 	}
-	id, _ := result.LastInsertId()
 
 	var newUser models.User
-	newUser.ID = int(id)
+	newUser.ID = id
 	newUser.Name = name
 	newUser.Token = token
 
@@ -55,7 +54,7 @@ func (r *UserRepository) GetUserByToken(token string) (models.User, error) {
 }
 
 // tokenが一致するユーザーのnameを更新する
-func (r *UserRepository) UpdateUserNameByToken(token string, name string) error {
+func (r *UserRepository) UpdateUserNameByToken(token, name string) error {
 	const sqlUpdateUserNameByToken = `
 		UPDATE users
 		SET name = ?

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -20,9 +20,10 @@ func NewUserService(r repositories.UserRepository) *UserService {
 // ハンドラー UserCreateHandler 用のサービスメソッド
 func (s *UserService) UserCreateService(name string) (models.User, error) {
 
+	id := uuid.GenerateUUID()
 	token := uuid.GenerateUUID()
 
-	newUser, err := s.repository.CreateUser(name, token)
+	newUser, err := s.repository.CreateUser(id, name, token)
 	if err != nil {
 		return models.User{}, err
 	}


### PR DESCRIPTION
## step5: ガチャに関連するテーブルの設計

### APIの要件
全てのAPIの仕様については[api-document.yaml](https://github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/blob/master/api-document.yaml)に記載。step5に関連するAPIを下記に記載。
#### ガチャ関連API
`POST /gacha/draw`
ガチャを引いてキャラクターを取得する処理を実装します。
獲得したキャラクターはユーザ所持キャラクターテーブルへ保存します。
同じ種類のキャラクターでもユーザは複数所持することができます。
キャラクターの確率は等倍ではなく、任意に変更できる。
Request
```
{
  "times": 0
}
```
Response
```
{
  "results": [
    {
      "characterID": "string",
      "name": "string"
    }
  ]
}
```
#### キャラクター関連API
`GET /character/list`
ユーザが所持しているキャラクター一覧情報を取得します。
Response
```
{
  "characters": [
    {
      "userCharacterID": "string",
      "characterID": "string",
      "name": "string"
    }
  ]
}
```
### ER図
```mermaid
erDiagram
    users ||--o{ results : has
    characters ||--o{ results : has

    users {
        int id PK "AUTO_INCREMENT"
        varchar(255) name "NOT NULL"
        varchar(255) token "NOT NULL UNIQUE"
    }

    characters {
        int id PK "AUTO_INCREMENT"
        varchar(255) name "NOT NULL"
        float probability "NOT NULL"
    }

    results {
        int id PK "AUTO_INCREMENT"
        int user_id FK "NOT NULL"
        int character_id FK "NOT NULL"
    }
```

### テーブル設計で考えたこと
#### usersテーブル
ユーザー情報を保存するテーブル。
tokenを元にユーザーを一意に決定することができるため、ユニーク制約をつけた。
#### charactersテーブル
キャラクターの不変的な内容(IDや名前など)を定義する情報テーブル。
排出確率をprobabilityとした。
#### resultsテーブル
ガチャの結果を保存するテーブル。
ユーザーは同じキャラクターを複数所持できることからユーザーとキャラクターはN:Nの関係なので、usersとcharactersの中間テーブルとなるようにusersのidとcharactersのidを外部キーとした。
### 相談したいこと
- ガチャやキャラクター関連APIのレスポンスのcharacterIDとuserCharacterIDがstringとなっていることからテーブルのidをvarcharにした方がいいのか。
