### PR TITLE
contextにuserIdをセットするように修正

### DIFF
--- a/api/middleware/x_token_auth.go
+++ b/api/middleware/x_token_auth.go
@@ -10,7 +10,7 @@ import (
 // contextに格納するUserIDのキー
 type UserIDKeyType struct{}
 
-func XTokenAuthMiddleware(h http.Handler, rep repositories.UserRepository) http.Handler {
+func XTokenAuthMiddleware(h http.Handler, uRep repositories.UserRepository) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		// リクエストヘッダーからX-Tokenを取得
 		xToken := r.Header.Get("X-Token")
@@ -20,7 +20,7 @@ func XTokenAuthMiddleware(h http.Handler, rep repositories.UserRepository) http.
 		}
 
 		// 取得したX-Tokenを持つユーザーが存在するか確認
-		user, err := rep.GetUserByToken(xToken)
+		user, err := uRep.GetByToken(xToken)
 		if err != nil || user.Token == "" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return

--- a/api/middleware/x_token_auth.go
+++ b/api/middleware/x_token_auth.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/repositories"
 )
 
-// contextにtokenを保存するための型
-type TokenType struct{}
+// contextに格納するUserIDのキー
+type UserIDKeyType struct{}
 
 func XTokenAuthMiddleware(h http.Handler, rep repositories.UserRepository) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
@@ -26,7 +26,8 @@ func XTokenAuthMiddleware(h http.Handler, rep repositories.UserRepository) http.
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), TokenType{}, xToken)
+		// contextにUserIDを格納
+		ctx := context.WithValue(r.Context(), UserIDKeyType{}, user.ID)
 		r = r.WithContext(ctx)
 		h.ServeHTTP(w, r)
 

--- a/api/router.go
+++ b/api/router.go
@@ -25,10 +25,10 @@ func NewRouter(db *sql.DB) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// ルーティングの設定
-	mux.Handle("/user/create", middleware.JSONContentTypeMiddleware(http.HandlerFunc(uCon.UserCreateHandler)))
+	mux.Handle("/user/create", middleware.JSONContentTypeMiddleware(http.HandlerFunc(uCon.CreateHandler)))
 	// /user/getと/user/updateではX-Tokenが必要なのでmiddlewareを適用
-	mux.Handle("/user/get", middleware.XTokenAuthMiddleware(middleware.JSONContentTypeMiddleware(http.HandlerFunc(uCon.UserGetHandler)), uRep))
-	mux.Handle("/user/update", middleware.XTokenAuthMiddleware(http.HandlerFunc(uCon.UserUpdateHandler), uRep))
+	mux.Handle("/user/get", middleware.XTokenAuthMiddleware(middleware.JSONContentTypeMiddleware(http.HandlerFunc(uCon.GetHandler)), uRep))
+	mux.Handle("/user/update", middleware.XTokenAuthMiddleware(http.HandlerFunc(uCon.UpdateNameHandler), uRep))
 
 	return mux
 }

--- a/controllers/services/services.go
+++ b/controllers/services/services.go
@@ -4,7 +4,7 @@ import "github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models
 
 // User関連を引き受けるサービス
 type UserServicer interface {
-	UserCreateService(name string) (models.User, error)
-	UserGetService(userId string) (models.User, error)
-	UserUpdateService(userId, name string) error
+	Create(name string) (models.User, error)
+	Get(userId string) (models.User, error)
+	UpdateName(userId, name string) error
 }

--- a/controllers/services/services.go
+++ b/controllers/services/services.go
@@ -5,6 +5,6 @@ import "github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models
 // User関連を引き受けるサービス
 type UserServicer interface {
 	UserCreateService(name string) (models.User, error)
-	UserGetService(token string) (models.User, error)
-	UserUpdateService(token string, name string) error
+	UserGetService(userId string) (models.User, error)
+	UserUpdateService(userId, name string) error
 }

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -57,9 +57,9 @@ func (c *UserController) UserGetHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	xToken, _ := r.Context().Value(middleware.TokenType{}).(string)
+	userId, _ := r.Context().Value(middleware.UserIDKeyType{}).(string)
 
-	user, err := c.service.UserGetService(xToken)
+	user, err := c.service.UserGetService(userId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -89,9 +89,9 @@ func (c *UserController) UserUpdateHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	xToken, _ := r.Context().Value(middleware.TokenType{}).(string)
+	userId, _ := r.Context().Value(middleware.UserIDKeyType{}).(string)
 
-	if err := c.service.UserUpdateService(xToken, req.Name); err != nil {
+	if err := c.service.UserUpdateService(userId, req.Name); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -11,17 +11,17 @@ import (
 
 // User用のコントローラ構造体
 type UserController struct {
-	service services.UserServicer
+	uSer services.UserServicer
 }
 
 // コンストラクタ関数
 func NewUserController(s services.UserServicer) *UserController {
-	return &UserController{service: s}
+	return &UserController{uSer: s}
 }
 
 // ハンドラーメソッドを定義
 // POST /user/create
-func (c *UserController) UserCreateHandler(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) CreateHandler(w http.ResponseWriter, r *http.Request) {
 	// POST以外のリクエストはエラー
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -34,7 +34,7 @@ func (c *UserController) UserCreateHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	user, err := c.service.UserCreateService(req.Name)
+	user, err := c.uSer.Create(req.Name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -50,7 +50,7 @@ func (c *UserController) UserCreateHandler(w http.ResponseWriter, r *http.Reques
 }
 
 // GET /user/get
-func (c *UserController) UserGetHandler(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) GetHandler(w http.ResponseWriter, r *http.Request) {
 	// GET以外のリクエストはエラー
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -59,7 +59,7 @@ func (c *UserController) UserGetHandler(w http.ResponseWriter, r *http.Request) 
 
 	userId, _ := r.Context().Value(middleware.UserIDKeyType{}).(string)
 
-	user, err := c.service.UserGetService(userId)
+	user, err := c.uSer.Get(userId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -76,7 +76,7 @@ func (c *UserController) UserGetHandler(w http.ResponseWriter, r *http.Request) 
 }
 
 // PUT /user/update
-func (c *UserController) UserUpdateHandler(w http.ResponseWriter, r *http.Request) {
+func (c *UserController) UpdateNameHandler(w http.ResponseWriter, r *http.Request) {
 	// PUT以外のリクエストはエラー
 	if r.Method != http.MethodPut {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -91,7 +91,7 @@ func (c *UserController) UserUpdateHandler(w http.ResponseWriter, r *http.Reques
 
 	userId, _ := r.Context().Value(middleware.UserIDKeyType{}).(string)
 
-	if err := c.service.UserUpdateService(userId, req.Name); err != nil {
+	if err := c.uSer.UpdateName(userId, req.Name); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/repositories/user.go
+++ b/repositories/user.go
@@ -17,7 +17,7 @@ func NewUserRepository(db *sql.DB) UserRepository {
 }
 
 // nameとtokenから新規ユーザーを作成する
-func (r *UserRepository) CreateUser(id, name, token string) (models.User, error) {
+func (r *UserRepository) Create(id, name, token string) (models.User, error) {
 	const sqlInsertUser = `
 		INSERT INTO users (id, name, token)
 		VALUES (?, ?, ?);
@@ -37,7 +37,7 @@ func (r *UserRepository) CreateUser(id, name, token string) (models.User, error)
 }
 
 // tokenからユーザーを取得する
-func (r *UserRepository) GetUserByToken(token string) (models.User, error) {
+func (r *UserRepository) GetByToken(token string) (models.User, error) {
 	const sqlSelectUserByToken = `
 		SELECT id, name, token
 		FROM users
@@ -54,7 +54,7 @@ func (r *UserRepository) GetUserByToken(token string) (models.User, error) {
 }
 
 // idからユーザーを取得する
-func (r *UserRepository) GetUserById(userId string) (models.User, error) {
+func (r *UserRepository) GetById(userId string) (models.User, error) {
 	const sqlSelectUserById = `
 		SELECT id, name, token
 		FROM users
@@ -71,7 +71,7 @@ func (r *UserRepository) GetUserById(userId string) (models.User, error) {
 }
 
 // userIdが一致するユーザーのnameを更新する
-func (r *UserRepository) UpdateUserName(userId, name string) error {
+func (r *UserRepository) UpdateName(userId, name string) error {
 	const sqlUpdateUserNameByToken = `
 		UPDATE users
 		SET name = ?

--- a/repositories/user.go
+++ b/repositories/user.go
@@ -53,15 +53,32 @@ func (r *UserRepository) GetUserByToken(token string) (models.User, error) {
 	return user, nil
 }
 
-// tokenが一致するユーザーのnameを更新する
-func (r *UserRepository) UpdateUserNameByToken(token, name string) error {
+// idからユーザーを取得する
+func (r *UserRepository) GetUserById(userId string) (models.User, error) {
+	const sqlSelectUserById = `
+		SELECT id, name, token
+		FROM users
+		WHERE id = ?;
+	`
+
+	var user models.User
+	err := r.db.QueryRow(sqlSelectUserById, userId).Scan(&user.ID, &user.Name, &user.Token)
+	if err != nil {
+		return models.User{}, err
+	}
+
+	return user, nil
+}
+
+// userIdが一致するユーザーのnameを更新する
+func (r *UserRepository) UpdateUserName(userId, name string) error {
 	const sqlUpdateUserNameByToken = `
 		UPDATE users
 		SET name = ?
-		WHERE token = ?;
+		WHERE id = ?;
 	`
 
-	_, err := r.db.Exec(sqlUpdateUserNameByToken, name, token)
+	_, err := r.db.Exec(sqlUpdateUserNameByToken, name, userId)
 	if err != nil {
 		return err
 	}

--- a/services/repositories/repositories.go
+++ b/services/repositories/repositories.go
@@ -6,5 +6,6 @@ import "github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models
 type UserRepository interface {
 	CreateUser(name string, token string) (models.User, error)
 	GetUserByToken(token string) (models.User, error)
-	UpdateUserNameByToken(token string, name string) error
+	GetUserById(userId string) (models.User, error)
+	UpdateUserName(userId, name string) error
 }

--- a/services/repositories/repositories.go
+++ b/services/repositories/repositories.go
@@ -4,8 +4,8 @@ import "github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models
 
 // User関連を引き受けるリポジトリインターフェース
 type UserRepository interface {
-	CreateUser(name string, token string) (models.User, error)
-	GetUserByToken(token string) (models.User, error)
-	GetUserById(userId string) (models.User, error)
-	UpdateUserName(userId, name string) error
+	Create(name string, token string) (models.User, error)
+	GetByToken(token string) (models.User, error)
+	GetById(userId string) (models.User, error)
+	UpdateName(userId, name string) error
 }

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -32,9 +32,9 @@ func (s *UserService) UserCreateService(name string) (models.User, error) {
 }
 
 // ハンドラー UserGetHandler 用のサービスメソッド
-func (s *UserService) UserGetService(token string) (models.User, error) {
+func (s *UserService) UserGetService(userId string) (models.User, error) {
 
-	user, err := s.repository.GetUserByToken(token)
+	user, err := s.repository.GetUserById(userId)
 	if err != nil {
 		return models.User{}, err
 	}
@@ -43,9 +43,9 @@ func (s *UserService) UserGetService(token string) (models.User, error) {
 }
 
 // ハンドラー UserUpdateHandler 用のサービスメソッド
-func (s *UserService) UserUpdateService(token string, name string) error {
+func (s *UserService) UserUpdateService(userId, name string) error {
 
-	err := s.repository.UpdateUserNameByToken(token, name)
+	err := s.repository.UpdateUserName(userId, name)
 	if err != nil {
 		return err
 	}

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -9,21 +9,21 @@ import (
 // サービス構造体を定義
 type UserService struct {
 	// userRepositoryを埋め込む
-	repository repositories.UserRepository
+	uRep repositories.UserRepository
 }
 
 // サービスのコンストラクタ
 func NewUserService(r repositories.UserRepository) *UserService {
-	return &UserService{repository: r}
+	return &UserService{uRep: r}
 }
 
-// ハンドラー UserCreateHandler 用のサービスメソッド
-func (s *UserService) UserCreateService(name string) (models.User, error) {
+// ハンドラー CreateHandler 用のサービスメソッド
+func (s *UserService) Create(name string) (models.User, error) {
 
 	id := uuid.GenerateUUID()
 	token := uuid.GenerateUUID()
 
-	newUser, err := s.repository.CreateUser(id, name, token)
+	newUser, err := s.uRep.Create(id, name, token)
 	if err != nil {
 		return models.User{}, err
 	}
@@ -31,10 +31,10 @@ func (s *UserService) UserCreateService(name string) (models.User, error) {
 	return newUser, nil
 }
 
-// ハンドラー UserGetHandler 用のサービスメソッド
-func (s *UserService) UserGetService(userId string) (models.User, error) {
+// ハンドラー GetHandler 用のサービスメソッド
+func (s *UserService) Get(userId string) (models.User, error) {
 
-	user, err := s.repository.GetUserById(userId)
+	user, err := s.uRep.GetById(userId)
 	if err != nil {
 		return models.User{}, err
 	}
@@ -42,10 +42,10 @@ func (s *UserService) UserGetService(userId string) (models.User, error) {
 	return user, nil
 }
 
-// ハンドラー UserUpdateHandler 用のサービスメソッド
-func (s *UserService) UserUpdateService(userId, name string) error {
+// ハンドラー UpdateNameHandler 用のサービスメソッド
+func (s *UserService) UpdateName(userId, name string) error {
 
-	err := s.repository.UpdateUserName(userId, name)
+	err := s.uRep.UpdateName(userId, name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 実装
コミット：https://github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/commit/f513d24db310b9256800e5fd536e40a099afd802
XTokenAuthMiddlewareでtokenから一意なユーザーを取得した後、contextにそのままtokenをセットしてしまっていた部分を修正し、userIDを渡すようにした。
これに伴い、userIdで一意なユーザーを取得するようにリポジトリのメソッドの追加やコントローラー層やサービス層の修正を行った。

コミット：https://github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/commit/41c1790dd2e0a8042e1e44d9ce1d5e6272d2b6b8
サービスのメソッドにserviceとついていたり、userリポジトリでのメソッドの名前がCreateUserとなっているなど名前が冗長になっていたので端的な名称に変更するリファクタを行った。

## 動作検証
POST /user/create
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/abb370cb-fe71-4d1d-8840-d037673ad61e">

GET /user/create
<img width="939" alt="image" src="https://github.com/user-attachments/assets/2f74ffa1-d820-429a-8cbf-26bff17caca3">

PUT /user/update
<img width="945" alt="image" src="https://github.com/user-attachments/assets/8d077a7a-a69d-4547-882f-29db7c596b1b">
