### PR TITLE
ガチャ実行APIの実装

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -22,6 +22,11 @@ func NewRouter(db *sql.DB) *http.ServeMux {
 	ucSer := services.NewUserCharacterService(ucRep)
 	ucCon := controllers.NewUserCharacterController(ucSer)
 
+	// gacha draw関連
+	cRep := repositories.NewCharacterRepository(db)
+	gdSer := services.NewGachaDrawService(ucRep, cRep)
+	gdCon := controllers.NewGachaDrawController(gdSer)
+
 	// register routes
 	mux := http.NewServeMux()
 
@@ -30,6 +35,9 @@ func NewRouter(db *sql.DB) *http.ServeMux {
 	// /user/getと/user/updateではX-Tokenが必要なのでmiddlewareを適用
 	mux.Handle("/user/get", middleware.XTokenAuthMiddleware(middleware.JSONContentTypeMiddleware(http.HandlerFunc(uCon.GetHandler)), uRep))
 	mux.Handle("/user/update", middleware.XTokenAuthMiddleware(http.HandlerFunc(uCon.UpdateNameHandler), uRep))
+
+	// /gacha/drawではX-Tokenが必要なのでmiddlewareを適用
+	mux.Handle("/gacha/draw", middleware.XTokenAuthMiddleware(middleware.JSONContentTypeMiddleware(http.HandlerFunc(gdCon.DrawHandler)), uRep))
 
 	// /character/listではX-Tokenが必要なのでmiddlewareを適用
 	mux.Handle("/character/list", middleware.XTokenAuthMiddleware(middleware.JSONContentTypeMiddleware(http.HandlerFunc(ucCon.GetListHandler)), uRep))

--- a/controllers/gacha_draw_controller.go
+++ b/controllers/gacha_draw_controller.go
@@ -1,0 +1,74 @@
+package controllers
+
+import (
+	"encoding/json"
+
+	"net/http"
+
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/api/middleware"
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/controllers/services"
+)
+
+// GachaDraw用のコントローラ構造体
+type GachaDrawController struct {
+	service services.GachaDrawServicer
+}
+
+// コンストラクタ関数
+func NewGachaDrawController(s services.GachaDrawServicer) *GachaDrawController {
+	return &GachaDrawController{service: s}
+}
+
+// ハンドラーメソッドを定義
+// POST /gacha/draw
+func (c *GachaDrawController) DrawHandler(w http.ResponseWriter, r *http.Request) {
+	// POST以外のリクエストはエラー
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userId, ok := r.Context().Value(middleware.UserIDKeyType{}).(string)
+	if !ok {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	// リクエストボディをパース
+	var req GachaDrawRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// timesが0未満の場合はエラー
+	if req.Times < 0 {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	// ガチャを引く
+	results, err := c.service.Draw(req.Times, userId)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	gachaResults := make([]GachaResult, 0, len(results))
+	for _, character := range results {
+		gachaResults = append(gachaResults, GachaResult{
+			CharacterID: character.CharacterID,
+			Name:        character.Name,
+		})
+	}
+
+	res := &GachaDrawResponse{
+		Results: gachaResults,
+	}
+
+	if err := json.NewEncoder(w).Encode(res); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+}

--- a/controllers/request.go
+++ b/controllers/request.go
@@ -1,6 +1,5 @@
 package controllers
 
-// ユーザーのリクエストボディを定義
 type (
 	// /user/create
 	UserCreateRequest struct {
@@ -10,5 +9,10 @@ type (
 	// /user/update
 	UserUpdateRequest struct {
 		Name string `json:"name"`
+	}
+
+	// /gacha/draw
+	GachaDrawRequest struct {
+		Times int `json:"times"`
 	}
 )

--- a/controllers/response.go
+++ b/controllers/response.go
@@ -11,6 +11,15 @@ type (
 		Name string `json:"name"`
 	}
 
+	// /gacha/draw
+	GachaResult struct {
+		CharacterID string `json:"characterID"`
+		Name        string `json:"name"`
+	}
+	GachaDrawResponse struct {
+		Results []GachaResult `json:"results"`
+	}
+
 	// /character/list
 	UserCharacter struct {
 		UserCharacterID string `json:"userCharacterID"`

--- a/controllers/services/services.go
+++ b/controllers/services/services.go
@@ -1,12 +1,19 @@
 package services
 
-import "github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models"
+import (
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models"
+)
 
 // User関連を引き受けるサービス
 type UserServicer interface {
 	Create(name string) (models.User, error)
 	Get(userId string) (models.User, error)
 	UpdateName(userId, name string) error
+}
+
+// GacheDraw関連を引き受けるサービス
+type GachaDrawServicer interface {
+	Draw(times int, userId string) ([]models.GachaResult, error)
 }
 
 // UserCharacter関連を引き受けるサービス

--- a/controllers/user_character_controller.go
+++ b/controllers/user_character_controller.go
@@ -21,7 +21,6 @@ func NewUserCharacterController(s services.UserCharacterServicer) *UserCharacter
 }
 
 // ハンドラーメソッドを定義
-
 // GET /character/list
 func (c *UserCharacterController) GetListHandler(w http.ResponseWriter, r *http.Request) {
 	// GET以外のリクエストはエラー
@@ -30,7 +29,11 @@ func (c *UserCharacterController) GetListHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	userId, _ := r.Context().Value(middleware.UserIDKeyType{}).(string)
+	userId, ok := r.Context().Value(middleware.UserIDKeyType{}).(string)
+	if !ok {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
 
 	// userIdを元に一致するユーザーが所持するキャラクターを取得
 	characterList, err := c.service.List(userId)

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -57,7 +57,11 @@ func (c *UserController) GetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userId, _ := r.Context().Value(middleware.UserIDKeyType{}).(string)
+	userId, ok := r.Context().Value(middleware.UserIDKeyType{}).(string)
+	if !ok {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
 
 	user, err := c.uSer.Get(userId)
 	if err != nil {
@@ -89,7 +93,11 @@ func (c *UserController) UpdateNameHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	userId, _ := r.Context().Value(middleware.UserIDKeyType{}).(string)
+	userId, ok := r.Context().Value(middleware.UserIDKeyType{}).(string)
+	if !ok {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
 
 	if err := c.uSer.UpdateName(userId, req.Name); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/models/character.go
+++ b/models/character.go
@@ -1,0 +1,8 @@
+package models
+
+// Characterの構造体
+type Character struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Probability float64 `json:"probability"`
+}

--- a/models/character.go
+++ b/models/character.go
@@ -2,9 +2,9 @@ package models
 
 // Characterの構造体
 type Character struct {
-	ID          string  `json:"id"`
-	Name        string  `json:"name"`
-	Probability float64 `json:"probability"`
+	ID          string
+	Name        string
+	Probability float64
 }
 
 type GachaResult struct {

--- a/models/character.go
+++ b/models/character.go
@@ -6,3 +6,8 @@ type Character struct {
 	Name        string  `json:"name"`
 	Probability float64 `json:"probability"`
 }
+
+type GachaResult struct {
+	CharacterID string
+	Name        string
+}

--- a/models/user.go
+++ b/models/user.go
@@ -2,7 +2,7 @@ package models
 
 // ユーザーの構造体
 type User struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Token string `json:"token"`
+	ID    string
+	Name  string
+	Token string
 }

--- a/models/user_character.go
+++ b/models/user_character.go
@@ -11,3 +11,9 @@ type UserCharacter struct {
 type CharacterList struct {
 	Characters []UserCharacter `json:"characters"`
 }
+
+// users_charactersテーブルにインサートするための構造体
+type UserCharacterInsert struct {
+	ID          string `json:"id"`
+	CharacterID string `json:"characterID"`
+}

--- a/models/user_character.go
+++ b/models/user_character.go
@@ -2,18 +2,18 @@ package models
 
 // UserCharacterの構造体
 type UserCharacter struct {
-	UserCharacterID string `json:"userCharacterID"`
-	CharacterID     string `json:"characterID"`
-	Name            string `json:"name"`
+	UserCharacterID string
+	CharacterID     string
+	Name            string
 }
 
 // CharacterListの構造体
 type CharacterList struct {
-	Characters []UserCharacter `json:"characters"`
+	Characters []UserCharacter
 }
 
 // users_charactersテーブルにインサートするための構造体
 type UserCharacterInsert struct {
-	ID          string `json:"id"`
-	CharacterID string `json:"characterID"`
+	ID          string
+	CharacterID string
 }

--- a/models/user_character.go
+++ b/models/user_character.go
@@ -11,9 +11,3 @@ type UserCharacter struct {
 type CharacterList struct {
 	Characters []UserCharacter
 }
-
-// users_charactersテーブルにインサートするための構造体
-type UserCharacterInsert struct {
-	ID          string
-	CharacterID string
-}

--- a/repositories/character.go
+++ b/repositories/character.go
@@ -1,0 +1,39 @@
+package repositories
+
+import (
+	"database/sql"
+
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models"
+)
+
+// リポジトリ構造体を定義
+type CharacterRepository struct {
+	db *sql.DB
+}
+
+// リポジトリのコンストラクタ
+func NewCharacterRepository(db *sql.DB) CharacterRepository {
+	return CharacterRepository{db: db}
+}
+
+// キャラクター全件取得
+func (r *CharacterRepository) GetAllList() ([]models.Character, error) {
+	const query = `SELECT id, name, probability FROM characters;`
+
+	rows, err := r.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var characters []models.Character
+	for rows.Next() {
+		var character models.Character
+		if err := rows.Scan(&character.ID, &character.Name, &character.Probability); err != nil {
+			return nil, err
+		}
+		characters = append(characters, character)
+	}
+
+	return characters, nil
+}

--- a/repositories/user_character.go
+++ b/repositories/user_character.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models"
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/pkg/uuid"
 )
 
 // リポジトリ構造体を定義
@@ -46,19 +47,19 @@ func (r *UserCharacterRepository) GetList(userId string) ([]models.UserCharacter
 }
 
 // ガチャ結果をusers_charactersテーブルにバルクインサートする
-func (r *UserCharacterRepository) InsertBulk(userId string, characters []models.UserCharacterInsert) error {
-	if len(characters) == 0 {
+func (r *UserCharacterRepository) InsertBulk(userId string, gachaResults []models.GachaResult) error {
+	if len(gachaResults) == 0 {
 		return nil
 	}
 
 	// クエリのプレースホルダーを生成
-	valueStrings := make([]string, 0, len(characters))
-	valueArgs := make([]interface{}, 0, len(characters)*3)
-	for _, character := range characters {
+	valueStrings := make([]string, 0, len(gachaResults))
+	valueArgs := make([]any, 0, len(gachaResults)*3)
+	for _, g := range gachaResults {
 		valueStrings = append(valueStrings, "(?, ?, ?)")
-		valueArgs = append(valueArgs, character.ID)
+		valueArgs = append(valueArgs, uuid.GenerateUUID())
 		valueArgs = append(valueArgs, userId)
-		valueArgs = append(valueArgs, character.CharacterID)
+		valueArgs = append(valueArgs, g.CharacterID)
 	}
 
 	// クエリ文字列を生成

--- a/repositories/user_character.go
+++ b/repositories/user_character.go
@@ -2,6 +2,8 @@ package repositories
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
 
 	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models"
 )
@@ -41,4 +43,31 @@ func (r *UserCharacterRepository) GetList(userId string) ([]models.UserCharacter
 	}
 
 	return userCharacters, nil
+}
+
+// ガチャ結果をusers_charactersテーブルにバルクインサートする
+func (r *UserCharacterRepository) InsertBulk(userId string, characters []models.UserCharacterInsert) error {
+	if len(characters) == 0 {
+		return nil
+	}
+
+	// クエリのプレースホルダーを生成
+	valueStrings := make([]string, 0, len(characters))
+	valueArgs := make([]interface{}, 0, len(characters)*3)
+	for _, character := range characters {
+		valueStrings = append(valueStrings, "(?, ?, ?)")
+		valueArgs = append(valueArgs, character.ID)
+		valueArgs = append(valueArgs, userId)
+		valueArgs = append(valueArgs, character.CharacterID)
+	}
+
+	// クエリ文字列を生成
+	query := fmt.Sprintf("INSERT INTO users_characters (id, user_id, character_id) VALUES %s",
+		strings.Join(valueStrings, ", "))
+
+	_, err := r.db.Exec(query, valueArgs...)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/services/gacha_draw_service.go
+++ b/services/gacha_draw_service.go
@@ -60,8 +60,19 @@ func selectRandomCharacters(characters []models.Character, times int) []models.G
 	for i := 0; i < times; i++ {
 		// 0~totalProbabilityの範囲で乱数を生成
 		randomValue := rand.Float64() * totalProbability
-		index := binarySearch(cumulativeProbabilities, randomValue)
-		selectedChar := characters[index]
+
+		// 二分探索で乱数に対応するキャラクターを選択
+		left, right := 0, len(cumulativeProbabilities)-1
+		for left < right {
+			mid := (left + right) / 2
+			if cumulativeProbabilities[mid] < randomValue {
+				left = mid + 1
+			} else {
+				right = mid
+			}
+		}
+
+		selectedChar := characters[left]
 
 		gachaResults[i] = models.GachaResult{
 			CharacterID: selectedChar.ID,
@@ -70,18 +81,4 @@ func selectRandomCharacters(characters []models.Character, times int) []models.G
 	}
 
 	return gachaResults
-}
-
-func binarySearch(cumulativeProbabilities []float64, target float64) int {
-	left, right := 0, len(cumulativeProbabilities)-1
-	for left < right {
-		mid := (left + right) / 2
-		if cumulativeProbabilities[mid] < target {
-			left = mid + 1
-		} else {
-			right = mid
-		}
-	}
-
-	return left
 }

--- a/services/gacha_draw_service.go
+++ b/services/gacha_draw_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"math/rand/v2"
+
 	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models"
 	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/pkg/uuid"
 	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/repositories"
@@ -34,8 +36,8 @@ func (s *GachaDrawService) Draw(times int, userId string) ([]models.GachaResult,
 	for i := 0; i < times; i++ {
 		// ガチャのIDをuuidで生成
 		id := uuid.GenerateUUID()
-		// ガチャロジックは一旦キャラクター固定で実装(todo: ガチャロジックの実装)
-		character := characters[0]
+
+		character := selectRandomCharacter(characters)
 		// ガチャの結果をDBにバルクインサートするための構造体に追加
 		userCharacterInserts = append(userCharacterInserts, models.UserCharacterInsert{
 			ID:          id,
@@ -54,4 +56,25 @@ func (s *GachaDrawService) Draw(times int, userId string) ([]models.GachaResult,
 	}
 
 	return gachaResults, nil
+}
+
+// ガチャロジックを実装する
+// キャラクターの確率に応じてランダムにキャラクターを選択する
+func selectRandomCharacter(characters []models.Character) *models.Character {
+	totalProbability := 0.0
+	for _, char := range characters {
+		totalProbability += char.Probability
+	}
+
+	randomValue := rand.Float64() * totalProbability
+	cumulativeProbability := 0.0
+
+	for _, char := range characters {
+		cumulativeProbability += char.Probability
+		if cumulativeProbability > randomValue {
+			return &char
+		}
+	}
+
+	return nil
 }

--- a/services/gacha_draw_service.go
+++ b/services/gacha_draw_service.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/models"
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/pkg/uuid"
+	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/repositories"
+)
+
+// サービス構造体を定義
+type GachaDrawService struct {
+	// UserCharacterRepositoryを埋め込む
+	ucRep repositories.UserCharacterRepository
+	// CharacterRepositoryを埋め込む
+	cRep repositories.CharacterRepository
+}
+
+// サービスのコンストラクタ
+func NewGachaDrawService(ucRep repositories.UserCharacterRepository, cRep repositories.CharacterRepository) *GachaDrawService {
+	return &GachaDrawService{ucRep: ucRep, cRep: cRep}
+}
+
+// ハンドラー GachaDrawHandler 用のサービスメソッド
+func (s *GachaDrawService) Draw(times int, userId string) ([]models.GachaResult, error) {
+	// キャラクター全件取得
+	characters, err := s.cRep.GetAllList()
+	if err != nil {
+		return nil, err
+	}
+
+	// ガチャの結果をDBにバルクインサートするための構造体を作成
+	var userCharacterInserts []models.UserCharacterInsert
+	// ガチャ結果を保存するための構造体を作成
+	var gachaResults []models.GachaResult
+	for i := 0; i < times; i++ {
+		// ガチャのIDをuuidで生成
+		id := uuid.GenerateUUID()
+		// ガチャロジックは一旦キャラクター固定で実装(todo: ガチャロジックの実装)
+		character := characters[0]
+		// ガチャの結果をDBにバルクインサートするための構造体に追加
+		userCharacterInserts = append(userCharacterInserts, models.UserCharacterInsert{
+			ID:          id,
+			CharacterID: character.ID,
+		})
+		// ガチャ結果を保存するための構造体に追加
+		gachaResults = append(gachaResults, models.GachaResult{
+			CharacterID: character.ID,
+			Name:        character.Name,
+		})
+	}
+
+	// ガチャの結果をDBにバルクインサート
+	if err := s.ucRep.InsertBulk(userId, userCharacterInserts); err != nil {
+		return nil, err
+	}
+
+	return gachaResults, nil
+}

--- a/services/repositories/repositories.go
+++ b/services/repositories/repositories.go
@@ -10,7 +10,13 @@ type UserRepository interface {
 	UpdateName(userId, name string) error
 }
 
+// Character関連を引き受けるリポジトリインターフェース
+type CharacterRepository interface {
+	GetAllList() ([]models.Character, error)
+}
+
 // UserCharacter関連を引き受けるリポジトリインターフェース
 type UserCharacterRepository interface {
 	GetList(userId string) ([]models.UserCharacter, error)
+	InsertBulk(userId string, characters []models.UserCharacterInsert) error
 }

--- a/services/repositories/repositories.go
+++ b/services/repositories/repositories.go
@@ -18,5 +18,5 @@ type CharacterRepository interface {
 // UserCharacter関連を引き受けるリポジトリインターフェース
 type UserCharacterRepository interface {
 	GetList(userId string) ([]models.UserCharacter, error)
-	InsertBulk(userId string, characters []models.UserCharacterInsert) error
+	InsertBulk(userId string, characters []models.GachaResult) error
 }


### PR DESCRIPTION
## ガチャ実行APIの実装
ガチャを引いてキャラクターを取得する処理。
獲得したキャラクターはユーザ所持キャラクターテーブルへ保存する。
同じ種類のキャラクターでもユーザは複数所持することができる。
**リクエスト**
```
{
  "times": 0
}
```
**レスポンス**
```
{
  "results": [
    {
      "characterID": "string",
      "name": "string"
    }
  ]
}
```

## ガチャロジックの詳細について
1. キャラクターの確率の総和`totalProbability`を計算
2. 確立の累積和`cumulativeProbabilities`を計算
3. 0〜1の乱数に`totalProbability`を掛けることによって 0〜`totalProbability`の範囲の乱数を作成する
4. 3で生成した乱数が累積和のどのindexに当てはまるかを二分探索する
5. indexで指定したキャラクターをガチャで選ばれたものとする


## Issues
close #7 