### PR TITLE
認証ミドルウェアでアクセス時間・ユーザーID・リクエストパスをログ出力する

### DIFF
--- a/api/middleware/x_token_auth.go
+++ b/api/middleware/x_token_auth.go
@@ -2,7 +2,10 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/ShinnosukeSuzuki/techtrain-mission-ca-tech-dojo-golang/repositories"
 )
@@ -10,11 +13,21 @@ import (
 // contextに格納するUserIDのキー
 type UserIDKeyType struct{}
 
+// ログに出力する構造体を定義
+type AccessLogging struct {
+	Timestamp string `json:"timestamp"`
+	UserID    string `json:"user_id,omitempty"`
+	Path      string `json:"path"`
+	Status    int    `json:"status"`
+	Message   string `json:"message"`
+}
+
 func XTokenAuthMiddleware(h http.Handler, uRep repositories.UserRepository) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		// リクエストヘッダーからX-Tokenを取得
 		xToken := r.Header.Get("X-Token")
 		if xToken == "" {
+			logAccess(r, "", http.StatusUnauthorized, "X-Token is required")
 			http.Error(w, "X-Token is required", http.StatusUnauthorized)
 			return
 		}
@@ -22,9 +35,12 @@ func XTokenAuthMiddleware(h http.Handler, uRep repositories.UserRepository) http
 		// 取得したX-Tokenを持つユーザーが存在するか確認
 		user, err := uRep.GetByToken(xToken)
 		if err != nil || user.Token == "" {
+			logAccess(r, "", http.StatusUnauthorized, "Unauthorized")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+
+		logAccess(r, user.ID, http.StatusOK, "Authorized")
 
 		// contextにUserIDを格納
 		ctx := context.WithValue(r.Context(), UserIDKeyType{}, user.ID)
@@ -33,4 +49,22 @@ func XTokenAuthMiddleware(h http.Handler, uRep repositories.UserRepository) http
 
 	}
 	return http.HandlerFunc(fn)
+}
+
+func logAccess(r *http.Request, userID string, status int, message string) {
+	al := AccessLogging{
+		Timestamp: time.Now().Format("2006-01-02 15:04:05.000000 -0700 MST"),
+		UserID:    userID,
+		Path:      r.URL.Path,
+		Status:    status,
+		Message:   message,
+	}
+
+	// JSONに変換して出力
+	jsonLog, err := json.Marshal(al)
+	if err != nil {
+		fmt.Println("Error marshaling log:", err)
+		return
+	}
+	fmt.Println(string(jsonLog))
 }


### PR DESCRIPTION
## 実装
x-tokenによる認証ミドルウェアでリクエストの時刻、リクエストのパス、ステータスコード、メッセージ、認証に成功した場合はユーザーのIDをjsonで出力するようにした。

## 検証
#### 認証に成功した場合
```
{"timestamp":"2024-09-13 21:32:14.208039 +0900 JST","user_id":"a7abf496-3f37-488d-a74e-49b2b555c987","path":"/character/list","status":200,"message":"Authorized"}
```

#### x-tokenが一致するユーザーが存在せず認証に失敗した場合
```
{"timestamp":"2024-09-13 21:32:36.916163 +0900 JST","path":"/character/list","status":401,"message":"Unauthorized"}
```

#### x-tokenが空で認証に失敗した場合
```
{"timestamp":"2024-09-13 21:32:54.374093 +0900 JST","path":"/character/list","status":401,"message":"X-Token is required"}
```

## Issues
close #5 