### PR TITLE
codepipelineとcodebuildを使用したCICDの作成

### DIFF
--- a/infra/game-api-infrastructure/lib/constructs/cicd-resources.ts
+++ b/infra/game-api-infrastructure/lib/constructs/cicd-resources.ts
@@ -1,0 +1,164 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
+import * as codepipeline_actions from 'aws-cdk-lib/aws-codepipeline-actions';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import { Construct } from 'constructs';
+
+
+export interface CiCdResourcesProps {
+  readonly env: string;
+  readonly vpc: ec2.IVpc;
+  readonly ecrRepository: ecr.Repository;
+  readonly connectionArn: string;
+  readonly secretToken: string;
+}
+
+export class CiCdResources extends Construct {
+  public readonly buildProject: codebuild.PipelineProject;
+  public readonly pipeline: codepipeline.Pipeline;
+
+  constructor(scope: Construct, id: string, props: CiCdResourcesProps) {
+    super(scope, id);
+
+    const { env, vpc, ecrRepository, connectionArn, secretToken } = props;
+
+    // IAMロールの作成(cdk deployできる必要があるためAdministratorAccessを付与)
+    const codeBuildRole = new iam.Role(this, 'BuildProjectRole', {
+      assumedBy: new iam.ServicePrincipal('codebuild.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AdministratorAccess')
+      ]
+    });
+
+    // CodeBuild プロジェクトの作成
+    this.buildProject = new codebuild.PipelineProject(this, 'BuildProject', {
+      projectName: `Game-API-ECR-Push-Project-${env}`,
+      vpc,
+      role: codeBuildRole,
+      buildSpec: codebuild.BuildSpec.fromObject({
+        version: '0.2',
+        phases: {
+          pre_build: {
+            commands: [
+              // cdk-deployのためにcdkのインストール
+              "npm install -g aws-cdk",
+              // ECRへのログインとソースコードのコミットハッシュを取得
+              "echo Logging in to Amazon ECR...",
+              "aws --version",
+              "aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com",
+              "COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)",
+              "IMAGE_TAG=${COMMIT_HASH:=latest}",
+            ],
+          },
+          build: {
+            commands: [
+              // Dockerimageのビルドとタグ付け
+              "echo Build started on `date`",
+              "echo Building the Docker image...",
+              "docker build -f ./build/Dockerfile -t $REPOSITORY_URI:latest .",
+              "docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG",
+            ],
+          },
+          post_build: {
+            commands: [
+              // ECRへのプッシュ
+              "echo Build completed on `date`",
+              "echo Pushing the Docker images...",
+              "docker push $REPOSITORY_URI:$IMAGE_TAG",
+              "docker push $REPOSITORY_URI:latest",
+              // SSM パラメータの更新
+              "aws ssm put-parameter --name $PARAMETER_STORE_NAME --value $IMAGE_TAG --type String --overwrite",
+              // 新しいタグを使ってタスク定義を更新(cdk deploy)
+              "echo Updating ECS service...",
+              "cd infra/game-api-infrastructure",
+              "npm install",
+              "cdk deploy --require-approval never",
+            ],
+          },
+        }
+      }),
+      environment: {
+        buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4,
+      },
+      environmentVariables: {
+        AWS_DEFAULT_REGION: { value: cdk.Stack.of(this).region },
+        AWS_ACCOUNT_ID: { value: cdk.Stack.of(this).account },
+        REPOSITORY_URI: { value: ecrRepository.repositoryUri },
+        PARAMETER_STORE_NAME: { value: `/ECR/game-api-${env.toLowerCase()}/tag`},
+      }
+    });
+
+    // CodePipeline の作成
+    // ソースステージ
+    const sourceOutput = new codepipeline.Artifact();
+    const sourceAction = new codepipeline_actions.CodeStarConnectionsSourceAction({
+      actionName: 'Source',
+      owner: 'ShinnosukeSuzuki',
+      repo: 'techtrain-mission-ca-tech-dojo-golang',
+      branch: env === 'Prod' ? 'main' : 'develop',
+      output: sourceOutput,
+      connectionArn: connectionArn,
+      triggerOnPush: false,
+    });
+
+    // ビルドステージ
+    const buildAction = new codepipeline_actions.CodeBuildAction({
+      actionName: 'Build',
+      project: this.buildProject,
+      input: sourceOutput,
+      outputs: [new codepipeline.Artifact()], // 出力アーティファクトが必要な場合
+    });
+
+    this.pipeline = new codepipeline.Pipeline(this, 'Pipeline', {
+      pipelineName: `Game-API-ECR-Push-Pipeline-${env}`,
+      stages: [
+        {
+          stageName: 'Source',
+          actions: [sourceAction],
+        },
+        {
+          stageName: 'Build',
+          actions: [buildAction],
+        },
+      ],
+    });
+
+    const webhook = new codepipeline.CfnWebhook(this, 'WebhookResource', {
+      authentication: 'GITHUB_HMAC',
+      authenticationConfiguration: {
+        secretToken: secretToken,
+      },
+      // GitHub の Release イベントで送られてくるペイロードを通すためのフィルター
+      filters: [
+        {
+          jsonPath: '$.action',
+          matchEquals: 'closed', // main ブランチに PR がマージされたときはclosedになる
+        },
+      ],
+      targetAction: sourceAction.actionProperties.actionName,
+      targetPipeline: this.pipeline.pipelineName,
+      targetPipelineVersion: 1,
+      // GitHub 側で Webhook を手動で作成する
+      registerWithThirdParty: false,
+    });
+
+    // Webhook のエンドポイントを出力する
+    new cdk.CfnOutput(this, 'WebhookUrl', {
+      value: webhook.attrUrl,
+    });
+
+    // CodePipeline に CodeBuild の権限を付与
+    this.pipeline.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        'codebuild:BatchGetBuilds',
+        'codebuild:StartBuild',
+        'codebuild:StopBuild',
+      ],
+      resources: [ this.buildProject.projectArn ],
+    }));
+  }
+}

--- a/infra/game-api-infrastructure/lib/constructs/network-resources.ts
+++ b/infra/game-api-infrastructure/lib/constructs/network-resources.ts
@@ -73,7 +73,7 @@ export class NetworkResources extends Construct {
 
     // ALB, ECS, RDS, 踏み台のセキュリティグループのインバウンドルールの設定
     // 家のIPアドレスからのみALBにアクセス可能
-    this.albSecurityGroup.addIngressRule(ec2.Peer.ipv4(`${process.env.MY_IP}/32`), ec2.Port.tcp(80), 'Allow HTTP traffic from my IP');
+    this.albSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(80), 'Allow HTTP traffic from anywhere');
     this.ecsSecurityGroup.addIngressRule(this.albSecurityGroup, ec2.Port.tcp(8080), 'Allow HTTP traffic from ALB');
     this.rdsSecurityGroup.addIngressRule(this.ecsSecurityGroup, ec2.Port.tcp(3306), 'Allow MySQL traffic from ECS');
     this.rdsSecurityGroup.addIngressRule(this.bastionSecurityGroup, ec2.Port.tcp(3306), 'Allow MySQL traffic from Bastion');

--- a/infra/game-api-infrastructure/lib/game-api-infrastructure-stack.ts
+++ b/infra/game-api-infrastructure/lib/game-api-infrastructure-stack.ts
@@ -75,15 +75,12 @@ export class GameApiInfrastructureStack extends cdk.Stack {
 
     // codepielineで使用するconnectionarnをsecretsmanagerから取得
     const connectionArn = secretsmanager.Secret.fromSecretNameV2(this, 'ConnectionArn', 'ca-tech-dojo-golang-connection-arn').secretValueFromJson('ARN').unsafeUnwrap();
-    // webhook secretTokenをsecretsmanagerから取得
-    const secretToken = secretsmanager.Secret.fromSecretNameV2(this, 'githubWebhookSecretToken', 'github-webhook-secret-token').secretValue.unsafeUnwrap();
     // CICDResources をインスタンス化
     const cicdResources = new CiCdResources(this, `CiCdResources-${env}`, {
       env,
       vpc: networkResources.vpc,
       ecrRepository,
       connectionArn,
-      secretToken
     });
   }
 }

--- a/infra/game-api-infrastructure/lib/game-api-infrastructure-stack.ts
+++ b/infra/game-api-infrastructure/lib/game-api-infrastructure-stack.ts
@@ -1,12 +1,14 @@
 import * as cdk from 'aws-cdk-lib';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 import { NetworkResources } from './constructs/network-resources';
 import { DatabaseResources } from './constructs/database-resources';
 import { BastionResources } from './constructs/bastion-resources';
 import { EcsFargateResources } from './constructs/ecs-fargate-resources';
 import { AlbResources } from './constructs/alb-resources';
+import { CiCdResources } from './constructs/cicd-resources';
 
 
 interface GameApiInfrastructureStackProps extends cdk.StackProps {
@@ -70,6 +72,18 @@ export class GameApiInfrastructureStack extends cdk.Stack {
       cpu: 0.25,
       httpListener: albResources.httpListener
     });
-    
+
+    // codepielineで使用するconnectionarnをsecretsmanagerから取得
+    const connectionArn = secretsmanager.Secret.fromSecretNameV2(this, 'ConnectionArn', 'ca-tech-dojo-golang-connection-arn').secretValueFromJson('ARN').unsafeUnwrap();
+    // webhook secretTokenをsecretsmanagerから取得
+    const secretToken = secretsmanager.Secret.fromSecretNameV2(this, 'githubWebhookSecretToken', 'github-webhook-secret-token').secretValue.unsafeUnwrap();
+    // CICDResources をインスタンス化
+    const cicdResources = new CiCdResources(this, `CiCdResources-${env}`, {
+      env,
+      vpc: networkResources.vpc,
+      ecrRepository,
+      connectionArn,
+      secretToken
+    });
   }
 }


### PR DESCRIPTION
# codepipelineとcodebuildを使用したCICDの作成

## codepipeline
下図のように当リポジトリのmainまたはdevelopブランチ(envによって場合分け)に対するpushをトリガーとした。infraディレクトリはdocker imageのbuildには全く関係ないためフィルターで除外とした。
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/9b795807-67e1-4e5a-af5d-bae4309e9b8e">

## codebuild
codepipelineからソースを受け取り実行する。
主に行うことは以下の4つ。
- docker imageのbuild
- ECRへのpush
- ECR tag情報を保存しているパラメータストアの更新
- cdk deploy：上記でECSで使用するimageのtagに差分があるため新しいtaskが作成されるがblue/greenではない。またinfaディレクトリの変更をpipelineのトリガーフィルターで除外しているのでcdkではECS以外の差分はないものみなせる。

## Issues
close #15 