### PR TITLE
環境別で読み込むcsvファイルを変更する

### DIFF
--- a/infra/game-api-infrastructure/bin/game-api-infrastructure.ts
+++ b/infra/game-api-infrastructure/bin/game-api-infrastructure.ts
@@ -7,11 +7,7 @@ const app = new cdk.App();
 const env = process.env.ENV || 'Dev';
 
 new GameApiInfrastructureStack(app, `GameApiInfrastructureStack${env}`, {
-  environment: process.env.ENV || 'Dev' as string,
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
+  environment: env as string,
 });
 
 cdk.Tags.of(app).add("ENV", env);

--- a/infra/game-api-infrastructure/lib/constructs/ecs-fargate-resources.ts
+++ b/infra/game-api-infrastructure/lib/constructs/ecs-fargate-resources.ts
@@ -66,6 +66,7 @@ export class EcsFargateResources extends Construct {
         REGION: cdk.Stack.of(this).region,
         BUCKET_NAME: charactersBucket.bucketName,
         FILE_PATH: 'characters.csv',
+        ENV: env,
       },
       secrets: {
         DATABASE: ecs.Secret.fromSecretsManager(adminUserPassword, 'dbname'),

--- a/main.go
+++ b/main.go
@@ -31,11 +31,7 @@ func main() {
 	}
 
 	// キャッシュを初期化
-	characterCache, err := cache.NewCharacterProbabilityCache(
-		os.Getenv("REGION"),
-		os.Getenv("BUCKET_NAME"),
-		os.Getenv("FILE_PATH"),
-	)
+	characterCache, err := cache.NewCharacterProbabilityCache()
 	if err != nil {
 		log.Fatalf("Failed to initialize cache: %v", err)
 	}


### PR DESCRIPTION
## 目的
ローカル環境ではローカルのcsvを読み込み、ECS環境ではS3のcsvファイルを読み込むようにするため。

## 検証
ENV変数を指定しない場合はローカルのcsvファイルを読み込み、ENV=Prodとしたときは、S3のcsvファイルを読み込んでキャッシュを作成することを確認した。
またガチャ実行APIについて、それぞれで確認し、正しいレスポンスが返ってきた。

## Issues
close #34 